### PR TITLE
Center download button in gallery card header

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -509,16 +509,18 @@ export default function GalleryPage() {
                 }}
               >
                 {/* --- Card Header: Checkbox, Download Center, Pencil Right --- */}
-                <div style={{
-                  display: "flex",
-                  alignItems: "center",
-                  minHeight: 38,
-                  marginBottom: 7,
-                  width: "100%",
-                  justifyContent: "space-between"
-                }}>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "auto 1fr auto",
+                    alignItems: "center",
+                    minHeight: 38,
+                    marginBottom: 7,
+                    width: "100%",
+                  }}
+                >
                   {/* Checkbox Left */}
-                  <div style={{ flex: "0 0 22px", display: "flex", alignItems: "center" }}>
+                  <div style={{ display: "flex", alignItems: "center" }}>
                     <input
                       type="checkbox"
                       style={{ width: 22, height: 22, accentColor: "#09713c", cursor: "pointer" }}
@@ -528,7 +530,7 @@ export default function GalleryPage() {
                     />
                   </div>
                   {/* Download Center */}
-                  <div style={{ flex: "1 1 auto", display: "flex", justifyContent: "center" }}>
+                  <div style={{ display: "flex", justifyContent: "center" }}>
                     <button
                       onClick={() => {
                         if (isGroup && groupImages.length > 1) {
@@ -555,8 +557,6 @@ export default function GalleryPage() {
                         transition: "all 0.15s",
                         boxShadow: internalOnly ? "none" : "0 1px 4px #09713c12",
                         padding: "0.15rem 0.7rem", // SMALLER
-                        marginLeft: internalOnly ? "auto" : undefined,
-                        marginRight: internalOnly ? "auto" : undefined,
                       }}
                     >
                       {internalOnly && <FaLock style={{ marginRight: 4, color: "#aaa" }} />}


### PR DESCRIPTION
## Summary
- refactor card header to use grid layout
- remove margin hack from download button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d517e8da48333bac34b6e7b97b4ea