### PR TITLE
Make Upload logo return to dashboard

### DIFF
--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import Select from "react-select";
 import { COLOR_OPTIONS } from "../Constants/colorOptions";
 import { db, auth } from "../services/firebase";
@@ -177,16 +178,18 @@ export default function UploadPage() {
     paddingLeft: "2rem",
     height: "300%"
   }}>
-    <img
-      src="/enviroshake-gallery/Enviroshake_logo/Enviroshake_white_logo.png"
-      alt="Enviroshake Logo"
-      style={{
-        maxHeight: "100%",
-        height: "100%",
-        width: "auto",
-        display: "block"
-      }}
-    />
+    <Link to="/dashboard">
+      <img
+        src="/enviroshake-gallery/Enviroshake_logo/Enviroshake_white_logo.png"
+        alt="Enviroshake Logo"
+        style={{
+          maxHeight: "100%",
+          height: "100%",
+          width: "auto",
+          display: "block"
+        }}
+      />
+    </Link>
   </div>
 
   <div style={{


### PR DESCRIPTION
## Summary
- add React Router Link to wrap logo on UploadPage
- import Link from react-router-dom

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d5b4cc6c08333aa7af05c0990b8f5