### PR TITLE
Fix filter spacing on gallery page

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -492,7 +492,7 @@ export default function GalleryPage() {
         </div>
       </div>
       {/* ====== FILTERS & SEARCH ====== */}
-      <div style={{ marginTop: "100px", padding: "2rem" }}>
+      <div style={{ marginTop: "1rem", padding: "2rem" }}>
         <div style={{ display: "flex", justifyContent: "center", alignItems: "center", marginBottom: "1rem", gap: "0.5rem" }}>
           <button onClick={clearAllFilters} style={{ padding: "0.5rem 1rem", borderRadius: "6px", fontWeight: "bold", border: "none", backgroundColor: "#f3f3f3" }}>
             Clear Filters


### PR DESCRIPTION
## Summary
- adjust margin before filters so there's less gap below the navbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d6ca5461c8333ad24ffdb31b9d900