### PR TITLE
Reduce space above upload card

### DIFF
--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -236,7 +236,7 @@ export default function UploadPage() {
 </div>
 
       <div style={{
-        marginTop: "35px",
+        marginTop: "20px",
         padding: "2rem 0",
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
## Summary
- decreased top margin so the upload form sits closer to the navbar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d719f666c8333a034bb2bbb052e5a