### PR TITLE
Adjust upload card width on desktop

### DIFF
--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -246,7 +246,7 @@ export default function UploadPage() {
       }}>
         <form onSubmit={handleSubmit} style={{
           width: "100%",
-          maxWidth: "540px",
+          maxWidth: "480px",
           background: "#fff",
           border: "1px solid #e3e3e3",
           borderRadius: "12px",


### PR DESCRIPTION
## Summary
- tweak UploadPage card `maxWidth` to 480px

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d730de424833388fd2f0a5bc217e8