### PR TITLE
Add subtle shadow to upload card

### DIFF
--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -251,7 +251,7 @@ export default function UploadPage() {
           border: "1px solid #e3e3e3",
           borderRadius: "12px",
           padding: "2.3rem 2rem 2rem 2rem",
-          boxShadow: "0 3px 16px 0 rgba(30,36,56,0.11)"
+          boxShadow: "0 4px 20px 0 rgba(30,36,56,0.15)"
         }}>
           <h3 style={{ textAlign: "center", marginBottom: "2rem", color: "#09713c", fontWeight: "bold" }}>Upload a New Image</h3>
           <div style={{ marginBottom: "1.0rem" }}>


### PR DESCRIPTION
## Summary
- tweak shadow for the upload card to stand out slightly more

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d74a036f083339a31f04ab7b8c5d4