### PR TITLE
Adjust gallery image size

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -659,7 +659,8 @@ export default function GalleryPage() {
                 <div
                   style={{
                     position: "relative",
-                    flex: 1,
+                    height: 160,
+                    width: "100%",
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",


### PR DESCRIPTION
## Summary
- tweak the gallery card image style so that images use a fixed height
- keep width at 100% and object-fit cover for proper cropping

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686e79e1ae988333945cc0025c34dc68