### PR TITLE
Fix gallery card height

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -558,7 +558,7 @@ export default function GalleryPage() {
                   boxSizing: "border-box",
                   position: "relative",
                   overflow: "hidden",
-                  height: 410,
+                  height: 320,
                   display: "flex",
                   flexDirection: "column",
                   justifyContent: "flex-start",


### PR DESCRIPTION
## Summary
- tweak GalleryPage card height to remove bottom white space

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686e7ccc367c8333afbb706580b32a05