### PR TITLE
Implement deterministic group ZIP downloads

### DIFF
--- a/Backend/routesDownloadGroup.js
+++ b/Backend/routesDownloadGroup.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const AWS = require("aws-sdk");
 const archiver = require("archiver");
-const path = require("path");
 
 const admin = require("firebase-admin");
 
@@ -34,7 +33,10 @@ router.get("/:groupId", async (req, res) => {
     const groupName = snapshot.docs[0].data().groupName || groupId;
 
     res.setHeader("Content-Type", "application/zip");
-    res.setHeader("Content-Disposition", `attachment; filename=${groupName}.zip`);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${groupName}.zip"`
+    );
 
     const archive = archiver("zip", { zlib: { level: 9 } });
     archive.pipe(res);
@@ -48,9 +50,8 @@ router.get("/:groupId", async (req, res) => {
         .getObject({ Bucket: process.env.AWS_S3_BUCKET, Key: s3Key })
         .createReadStream();
 
-      const ext = path.extname(s3Key);
       const idxStr = index.toString().padStart(3, "0");
-      const fileName = `${groupName}_${idxStr}${ext}`;
+      const fileName = `${groupName}_${idxStr}.jpg`;
 
       archive.append(s3Stream, { name: `${folderName}${fileName}` });
       index += 1;


### PR DESCRIPTION
## Summary
- ensure `/download-group/:groupId` names zip files after the group
- ensure images in the zip folder are sequentially named `groupName_###.jpg`
- quote the `Content-Disposition` filename to handle spaces

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686e8ebd87ec8333ac915b46c48668ba