### PR TITLE
Remove extensions from displayed image names

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -45,7 +45,7 @@ const OPTIONS = {
 const makeOptions = (arr) => arr.map(item => ({ label: item, value: item }));
 
 const formatImageName = (groupName, index) =>
-  `${groupName}_${String(index + 1).padStart(3, '0')}.jpg`;
+  `${groupName}_${String(index + 1).padStart(3, '0')}`;
 
 export default function GalleryPage() {
   const [images, setImages] = useState([]);


### PR DESCRIPTION
## Summary
- render image names without file extensions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686e96989d1c8333afc6016faae7f7fb