### PR TITLE
Fix grey button centering

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -613,6 +613,8 @@ export default function GalleryPage() {
                         borderRadius: "11px",
                         opacity: internalOnly ? 0.6 : 1,
                         cursor: "pointer",
+                        marginLeft: "auto",
+                        marginRight: "auto",
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",


### PR DESCRIPTION
## Summary
- ensure the greyed-out Download button is horizontally centered

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_686e9f457e948333a65df68e8aa77b03