### PR TITLE
Fix gallery card alignment

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -98,6 +98,60 @@ button:focus-visible {
   height: 100%;
 }
 
+/* Ensure uniform card height within the grid */
+.gallery-card.fixed-height {
+  height: 300px;
+}
+
+/* Reserved banner space at the top of each card */
+.gallery-card .internal-banner {
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 4px 0;
+  font-size: 0.96em;
+  color: #888;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.gallery-card .internal-banner.hidden {
+  visibility: hidden;
+}
+
+/* Image wrapper with consistent sizing */
+.gallery-card .image-wrapper {
+  position: relative;
+  height: 150px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+/* Group name limited to two lines */
+.gallery-card .gallery-name {
+  font-weight: 400;
+  font-size: 1.1rem;
+  margin-top: auto;
+  color: #135b37;
+  letter-spacing: 0.01em;
+  text-align: center;
+  border-top: 1px solid #e6e6e6;
+  padding-top: 6px;
+  line-height: 1.2;
+  margin-bottom: 0;
+  background: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 .gallery-card:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }

--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -529,7 +529,7 @@ export default function GalleryPage() {
           marginTop: "2rem",
           display: "grid",
           gridTemplateColumns: "repeat(5, 1fr)",
-          gridAutoRows: "1fr",
+          gridAutoRows: "300px",
           gap: "1.2rem",
         }}>
           {paginatedGroupIds.map((groupId) => {
@@ -544,7 +544,7 @@ export default function GalleryPage() {
             return (
               <div
                 key={groupId}
-                className="card gallery-card"
+                className="card gallery-card fixed-height"
                 style={{
                   border: "1px solid #ccc",
                   borderRadius: "12px",
@@ -616,37 +616,14 @@ export default function GalleryPage() {
                 </div>
 
                 {/* Internal Only Row */}
-                <div style={{
-                  margin: internalOnly ? "4px 0" : 0,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}>
-                  {internalOnly ? (
-                    <div style={{
-                      fontSize: "0.96em",
-                      color: "#888",
-                      fontWeight: 500,
-                      letterSpacing: "0.01em"
-                    }}>
-                      Internal Use Only – Not for Marketing
-                    </div>
-                  ) : null}
+                <div
+                  className={`internal-banner ${internalOnly ? '' : 'hidden'}`}
+                >
+                  Internal Use Only – Not for Marketing
                 </div>
 
                 {/* Main image */}
-                <div
-                  style={{
-                    position: "relative",
-                    height: 160,
-                    width: "100%",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    overflow: "hidden",
-                    marginBottom: 6,
-                  }}
-                >
+                <div className="image-wrapper">
                   <img
                     src={`${BUCKET_URL}/${firstImage.s3Key}`}
                     alt="Group Thumbnail"
@@ -684,25 +661,7 @@ export default function GalleryPage() {
 
 
                 {/* Name/footer */}
-                <div
-                  style={{
-                    fontWeight: 400,
-                    fontSize: "1.1rem",
-                    marginTop: "auto",
-                    color: "#135b37",
-                    letterSpacing: ".01em",
-                    textAlign: "center",
-                    borderTop: "1px solid #e6e6e6",
-                    paddingTop: 6,
-                    lineHeight: 1.2,
-                    marginBottom: 0,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "normal",
-                    overflowWrap: "anywhere",
-                    background: "#fff",
-                  }}
-                >
+                <div className="gallery-name">
                   {displayName}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- ensure fixed card height, banner area, and image sizing in gallery grid
- clamp gallery name text and update gallery card markup
- adjust gallery card CSS for consistent spacing

## Testing
- `npm run lint`
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_686fbd6cf7348333a6bcfc30bf3f6a2e