### PR TITLE
Fix ZIP header for group downloads

### DIFF
--- a/Backend/routesDownloadGroup.js
+++ b/Backend/routesDownloadGroup.js
@@ -35,11 +35,8 @@ router.get("/:groupId", async (req, res) => {
     const groupName = snapshot.docs[0].data().groupName || groupId;
     console.log(`Found ${snapshot.size} images for group: ${groupName}`);
 
-    res.setHeader("Content-Type", "application/zip");
-    res.setHeader(
-      "Content-Disposition",
-      `attachment; filename="${groupName}.zip"`
-    );
+    res.type("zip");
+    res.attachment(`${groupName}.zip`);
 
     const archive = archiver("zip", { zlib: { level: 9 } });
     archive.on("error", (archiveErr) => {


### PR DESCRIPTION
## Summary
- use `res.attachment` to set Content-Disposition when generating ZIP files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686ff3a7f0d4833381e6df8304be930a