### PR TITLE
Fix groupIds payload in download

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -227,7 +227,7 @@ export default function GalleryPage() {
       const res = await fetch("http://localhost:4000/download-multiple-groups", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ selectedCardIds })
+        body: JSON.stringify({ groupIds: selectedCardIds })
       });
       if (!res.ok) throw new Error("Failed to generate ZIP");
       const blob = await res.blob();


### PR DESCRIPTION
## Summary
- send `groupIds` in body when downloading selected groups

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687008ed8d9883339c1280cda20c918c