### PR TITLE
Fix filter dropdown z-index

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -224,6 +224,8 @@ button:focus-visible {
   padding: 2rem;
   border-radius: 12px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.07);
+  position: relative;
+  z-index: 5;
 }
 
 .filter-container .search-row {


### PR DESCRIPTION
## Summary
- ensure filter dropdown menus layer above badges by updating filter container z-index

## Testing
- `npm run lint`
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_687011ce7e2c8333a43e95bc3b953847