### PR TITLE
Update gallery modal styles

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -244,3 +244,27 @@ button:focus-visible {
   gap: 1.2rem;
   margin-bottom: 1.2rem;
 }
+
+/* Gallery modal styles */
+.photo-modal .modal-main-image {
+  display: block;
+  margin: 20px auto 16px;
+  max-height: 70vh;
+  object-fit: contain;
+}
+
+.photo-modal .swiper-button-prev,
+.photo-modal .swiper-button-next {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.photo-modal .swiper-button-prev:hover,
+.photo-modal .swiper-button-next:hover {
+  background: rgba(0, 0, 0, 0.05);
+}

--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -664,9 +664,15 @@ export default function GalleryPage() {
         </div>
       </div>
       {/* ====== MODALS ====== */}
-      <Modal open={modalOpen} onClose={() => setModalOpen(false)} center styles={{
-        modal: { padding: 0, background: "white", borderRadius: "10px", maxWidth: "950px" }
-      }}>
+      <Modal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        center
+        classNames={{ modal: 'photo-modal' }}
+        styles={{
+          modal: { padding: 0, background: "white", borderRadius: "10px", maxWidth: "950px" }
+        }}
+      >
         {modalImage && modalImage.groupImages && modalImage.groupImages.length > 1 ? (
           <div style={{ textAlign: 'center', padding: '1.5rem 1.5rem 0 1.5rem', maxWidth: 880 }}>
             <div style={{ marginBottom: '0.7rem', fontWeight: 400 }}>
@@ -690,7 +696,12 @@ export default function GalleryPage() {
                     <img
                       src={`${BUCKET_URL}/${img.s3Key}`}
                       alt=""
-                      style={{ maxHeight: "360px", maxWidth: "100%", borderRadius: "10px", margin: "0 auto" }}
+                      className="modal-main-image"
+                      style={{
+                        maxWidth: "100%",
+                        borderRadius: "10px",
+                        display: "block"
+                      }}
                     />
                     <span
                       className="delete-icon"
@@ -766,8 +777,11 @@ export default function GalleryPage() {
             <img
               src={modalImage.url}
               alt=""
+              className="modal-main-image"
               style={{
-                maxWidth: "100%", maxHeight: "410px", margin: "0 auto", borderRadius: "10px", display: "block"
+                maxWidth: "100%",
+                borderRadius: "10px",
+                display: "block"
               }}
             />
             <span


### PR DESCRIPTION
## Summary
- center gallery images within the modal popup
- scope modal styling with a custom CSS class
- style navigation arrows and large images

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68701e603e8c8333847b6ea6e838b9ae