### PR TITLE
Fix alignment of modal action buttons

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -908,7 +908,7 @@ export default function GalleryPage() {
                 />
               ))}
             </div>
-            <div className="modal-action-row" style={{ marginTop: "1rem" }}>
+            <div className="modal-action-row">
               <button
                 onClick={handleModalImageDownload}
                 className={`modal-download-btn ${modalImage.groupMeta && isInternalOnly(modalImage.groupMeta, modalImage.groupImages[modalIndex]) ? "disabled" : ""}`}
@@ -984,7 +984,7 @@ export default function GalleryPage() {
             >
               <FaTrashAlt />
             </span>
-            <div className="modal-action-row" style={{ marginTop: "1.3rem" }}>
+            <div className="modal-action-row">
               <button
                 onClick={handleModalImageDownload}
                 className={`modal-download-btn ${modalImage.groupMeta && isInternalOnly(modalImage.groupMeta, modalImage) ? "disabled" : ""}`}


### PR DESCRIPTION
## Summary
- remove inline margin from modal action row
- rely on CSS flexbox rules to center buttons

## Testing
- `npm --prefix Frontend run lint`
- `npm --prefix Backend test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68712314fc1c8333b5b60472367ba71b