### PR TITLE
Fix layout of gallery modal buttons

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -300,7 +300,9 @@ button:focus-visible {
 .photo-modal .modal-action-row {
   display: flex;
   justify-content: center;
-  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
   width: 100%;
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- adjust spacing for modal action buttons so the Download Image and Notes buttons sit side-by-side and center properly on small screens

## Testing
- `npm run lint`
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_687126b5a34c8333b66f646140d28de5