### PR TITLE
Fix gallery card height

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -93,7 +93,7 @@ button:focus-visible {
   border: 1px solid #e0e0e0;
   border-radius: 12px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
-  padding: 1rem;
+  padding: 0.5rem 1rem; /* reduced vertical padding to shorten height */
   transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- shorten gallery card padding to avoid overlap

## Testing
- `npm run lint`
- `npx vite build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_6871305ff1808333a2d2f931ca5819dd