### PR TITLE
Increase gallery row spacing

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -612,7 +612,8 @@ export default function GalleryPage() {
             display: "grid",
             gridTemplateColumns: "repeat(5, 1fr)",
             gridAutoRows: "300px",
-            gap: "1.2rem",
+            columnGap: "1.2rem",
+            rowGap: "1.6rem",
           }}
         >
           {paginatedGroupIds.map((groupId) => {


### PR DESCRIPTION
## Summary
- adjust gallery grid layout to add more vertical space between rows on the photo gallery page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68714a55d69883338653516df4d8e983