### PR TITLE
Reduce gap between image and separator

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -134,7 +134,7 @@ button:focus-visible {
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  margin-bottom: 6px;
+  margin-bottom: 3px;
 }
 
 /* Group name limited to two lines */


### PR DESCRIPTION
## Summary
- make gallery-card image-to-divider margin smaller

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68714c5f42fc8333a8845efacd3123b4