### PR TITLE
Fix single image download from modal

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -22,6 +22,7 @@ import "swiper/css";
 import "swiper/css/navigation";
 import { FaTrashAlt, FaLock, FaDownload } from "react-icons/fa";
 import { StickyNote } from "lucide-react";
+import { downloadSingleImage } from "../utils/download";
 
 const BUCKET_URL = "https://enviroshake-gallery-images.s3.amazonaws.com";
 
@@ -297,20 +298,22 @@ export default function GalleryPage() {
 
   const handleModalImageDownload = () => {
     if (!modalImage) return;
-    if (modalImage.groupImages && modalImage.groupImages.length > 1) {
-      const img = modalImage.groupImages[modalIndex];
-      const url = `${BUCKET_URL}/${img.s3Key}`;
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = url.split("/").pop() || "image.jpg";
-      link.click();
-    } else if (modalImage.url) {
-      const url = modalImage.url;
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = url.split("/").pop() || "image.jpg";
-      link.click();
+
+    let img = null;
+    if (modalImage.groupImages && modalImage.groupImages.length) {
+      img = modalImage.groupImages[modalIndex];
     }
+
+    const url = img ? `${BUCKET_URL}/${img.s3Key}` : modalImage.url;
+    if (!url) return;
+
+    const fileName =
+      img?.imageName ||
+      modalImage.imageName ||
+      img?.s3Key ||
+      modalImage.s3Key;
+
+    downloadSingleImage(url, fileName);
   };
 
   // DELETE HANDLERS

--- a/Frontend/src/utils/download.js
+++ b/Frontend/src/utils/download.js
@@ -1,0 +1,10 @@
+export function downloadSingleImage(url, fileName) {
+  if (!url) return;
+  const link = document.createElement('a');
+  link.href = url;
+  const defaultName = url.split('?')[0].split('/').pop() || 'image.jpg';
+  link.setAttribute('download', fileName || defaultName);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}


### PR DESCRIPTION
## Summary
- add helper util for downloading individual images
- use helper in `GalleryPage` modal download handler

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68750f463fc48333bbbadb46d6362e03