### PR TITLE
Improve download button behavior

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -295,6 +295,20 @@ export default function GalleryPage() {
     setIsDownloading(false);
   };
 
+  const handleDirectDownload = () => {
+    const img = modalImage.groupImages?.[modalIndex];
+    const url = img ? `${BUCKET_URL}/${img.s3Key}` : modalImage.url;
+    const filename =
+      img?.imageName || modalImage.imageName || img?.s3Key || "image.jpg";
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   async function deleteGroupAndAllPhotos(groupId) {
     const imgs = images.filter((img) => img.groupId === groupId);
     for (let img of imgs) {
@@ -872,19 +886,16 @@ export default function GalleryPage() {
               ))}
             </div>
             <div className="modal-action-row">
-              <a
-                href={modalImage.groupImages?.length ? `${BUCKET_URL}/${modalImage.groupImages[modalIndex]?.s3Key}` : modalImage.url}
-                download={modalImage.groupImages?.length ? modalImage.groupImages[modalIndex]?.imageName || "image.jpg" : modalImage.imageName || "image.jpg"}
+              <button
+                onClick={handleDirectDownload}
                 className={`modal-download-btn ${modalImage.groupMeta && isInternalOnly(modalImage.groupMeta, modalImage.groupImages?.[modalIndex] || modalImage) ? "disabled" : ""}`}
-                target="_blank"
-                rel="noopener noreferrer"
               >
                 <FaDownload />
                 {isInternalOnly(modalImage.groupMeta, modalImage.groupImages?.[modalIndex] || modalImage) && (
                   <FaLock style={{ color: "#888" }} />
                 )}
                 <span>Download Image</span>
-              </a>
+              </button>
               {/* NOTES POPUP BUTTON */}
               <button
                 onClick={handleOpenNotesPopup}
@@ -950,19 +961,16 @@ export default function GalleryPage() {
               <FaTrashAlt />
             </span>
             <div className="modal-action-row">
-                <a
-                  href={modalImage.groupImages?.length ? `${BUCKET_URL}/${modalImage.groupImages[modalIndex]?.s3Key}` : modalImage.url}
-                  download={modalImage.groupImages?.length ? modalImage.groupImages[modalIndex]?.imageName || "image.jpg" : modalImage.imageName || "image.jpg"}
+                <button
+                  onClick={handleDirectDownload}
                   className={`modal-download-btn ${modalImage.groupMeta && isInternalOnly(modalImage.groupMeta, modalImage.groupImages?.[modalIndex] || modalImage) ? "disabled" : ""}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
                 >
                   <FaDownload />
                   {isInternalOnly(modalImage.groupMeta, modalImage.groupImages?.[modalIndex] || modalImage) && (
                     <FaLock style={{ color: "#888" }} />
                   )}
                   <span>Download Image</span>
-                </a>
+                </button>
               {/* NOTES POPUP BUTTON */}
               <button
                 onClick={handleOpenNotesPopup}


### PR DESCRIPTION
## Summary
- enable direct download of modal images
- switch modal image links to buttons that call the new handler

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68752f228c1c8333b40c94e0869daf0b