### PR TITLE
Add debug logging for direct image download

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -307,6 +307,7 @@ const handleDirectDownload = async () => {
 
   try {
     const response = await fetch(url, { mode: "cors" });
+    console.log("🧪 Response status:", response.status);
 
     if (!response.ok) {
       console.error("❌ Fetch failed with status:", response.status);


### PR DESCRIPTION
## Summary
- add console log for the response status in `handleDirectDownload`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68753e10baf083339e1895bd3bfd06b5