### PR TITLE
Add content disposition for S3 uploads

### DIFF
--- a/Backend/server.js
+++ b/Backend/server.js
@@ -43,6 +43,7 @@ app.post("/generate-upload-url", async (req, res) => {
     Key: key,
     Expires: 60,
     ContentType: fileType,
+    ContentDisposition: "attachment",
   };
 
   try {


### PR DESCRIPTION
## Summary
- force S3 objects to download instead of opening in browser

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68764c122b4c833392c0f0558c520e7a