### PR TITLE
Add ContentDisposition to presigned uploads

### DIFF
--- a/Backend/package.json
+++ b/Backend/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "archiver": "^7.0.1",
     "aws-sdk": "^2.1692.0",
+    "@aws-sdk/client-s3": "^3.579.0",
+    "@aws-sdk/s3-request-presigner": "^3.579.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- include AWS SDK v3 client for generating presigned URLs
- set `ContentDisposition: 'attachment'` when generating a signed upload URL
- keep original AWS SDK v2 client for delete operations
- add AWS SDK v3 packages to backend dependencies

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6876500be0588333905f64387b345e70