### PR TITLE
Enable group downloads from modal

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -887,16 +887,22 @@ export default function GalleryPage() {
             <div className="modal-action-row">
               <button
                 onClick={() =>
-                  handleDownload(
-                    modalImage.groupImages?.[modalIndex] ?? modalImage,
-                  )
+                  modalImage.groupId
+                    ? handleDownloadGroup(modalImage.groupId)
+                    : handleDownload(
+                        modalImage.groupImages?.[modalIndex] ?? modalImage,
+                      )
                 }
-                disabled={!(
-                  (modalImage.groupImages?.[modalIndex]?.s3Key ||
-                    modalImage.groupImages?.[modalIndex]?.s3Url ||
-                    modalImage.s3Key ||
-                    modalImage.s3Url)
-                )}
+                disabled={
+                  modalImage.groupId
+                    ? false
+                    : !(
+                        (modalImage.groupImages?.[modalIndex]?.s3Key ||
+                          modalImage.groupImages?.[modalIndex]?.s3Url ||
+                          modalImage.s3Key ||
+                          modalImage.s3Url)
+                      )
+                }
                 className="modal-download-btn"
               >
                 <FaDownload />
@@ -969,16 +975,22 @@ export default function GalleryPage() {
             <div className="modal-action-row">
               <button
                 onClick={() =>
-                  handleDownload(
-                    modalImage.groupImages?.[modalIndex] ?? modalImage,
-                  )
+                  modalImage.groupId
+                    ? handleDownloadGroup(modalImage.groupId)
+                    : handleDownload(
+                        modalImage.groupImages?.[modalIndex] ?? modalImage,
+                      )
                 }
-                disabled={!(
-                  (modalImage.groupImages?.[modalIndex]?.s3Key ||
-                    modalImage.groupImages?.[modalIndex]?.s3Url ||
-                    modalImage.s3Key ||
-                    modalImage.s3Url)
-                )}
+                disabled={
+                  modalImage.groupId
+                    ? false
+                    : !(
+                        (modalImage.groupImages?.[modalIndex]?.s3Key ||
+                          modalImage.groupImages?.[modalIndex]?.s3Url ||
+                          modalImage.s3Key ||
+                          modalImage.s3Url)
+                      )
+                }
                 className="modal-download-btn"
               >
                 <FaDownload />


### PR DESCRIPTION
## Summary
- update modal download button to fetch ZIP for current group

## Testing
- `npm --prefix Frontend run lint`
- `node Frontend/node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_b_687666ff3cc88333aad5121afeb16c7d