### PR TITLE
Fix gallery modal header

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -817,6 +817,16 @@ export default function GalleryPage() {
                   modalIndex,
                 )}
               </div>
+              <div
+                style={{
+                  fontSize: "0.9rem",
+                  color: "#666",
+                  marginTop: 4,
+                  marginBottom: 8,
+                }}
+              >
+                {modalIndex + 1} of {modalImage.groupImages.length}
+              </div>
             </div>
             <Swiper
               modules={[Navigation]}


### PR DESCRIPTION
## Summary
- show image count in gallery modal without timestamp

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6876b53f22308333a124bfcdc433515d