### PR TITLE
Add photo upload button in GalleryPage modal

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -312,6 +312,21 @@ button:focus-visible {
   border-color: #09713c;
 }
 
+.thumbnail-row .add-thumb {
+  width: 64px;
+  height: 64px;
+  border-radius: 6px;
+  border: 2px dashed #09713c;
+  color: #09713c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 2rem;
+  background: #fff;
+}
+
 /* Modal action buttons */
 .photo-modal .modal-action-row {
   display: flex;
@@ -364,6 +379,25 @@ button:focus-visible {
   background: #f0f0f0;
   color: #09713c;
   transform: scale(1.05);
+}
+
+.photo-modal .modal-add-btn {
+  width: 64px;
+  height: 64px;
+  background: #fff;
+  border: 2px dashed #09713c;
+  border-radius: 0.75rem;
+  color: #09713c;
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.photo-modal .modal-add-btn:hover {
+  background: #f0f0f0;
 }
 
 .photo-modal .modal-download-btn:hover:not(.disabled) {


### PR DESCRIPTION
## Summary
- add hidden file input and handlers to upload additional images within modal
- append Add Photo button in multi-image thumbnail rows and single-image action rows
- replicate UploadPage upload logic for adding photos to existing group
- style Add Photo buttons to match thumbnails and modal actions

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_6877abb78c808333ade3b5b7e478b584