### PR TITLE
Fix Add Photo button placement

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -993,7 +993,7 @@ export default function GalleryPage() {
                   }}
                 />
               ))}
-              {modalImage.groupId && (
+              {modalImage.groupImages.length > 1 && (
                 <div
                   className="thumbnail add-thumb"
                   title="Add Photo"
@@ -1008,19 +1008,6 @@ export default function GalleryPage() {
               )}
             </div>
             <div className="modal-action-row">
-              {modalImage.groupId && (
-                <div
-                  className="modal-add-btn"
-                  title="Add Photo"
-                  onClick={openAddPhotoDialog}
-                  style={{
-                    opacity: addingPhotos ? 0.6 : 1,
-                    pointerEvents: addingPhotos ? "none" : "auto",
-                  }}
-                >
-                  +
-                </div>
-              )}
               <button
                 onClick={() =>
                   modalImage.groupId
@@ -1097,6 +1084,17 @@ export default function GalleryPage() {
               <FaTrashAlt />
             </span>
             <div className="modal-action-row">
+              <div
+                className="modal-add-btn"
+                title="Add Photo"
+                onClick={openAddPhotoDialog}
+                style={{
+                  opacity: addingPhotos ? 0.6 : 1,
+                  pointerEvents: addingPhotos ? "none" : "auto",
+                }}
+              >
+                +
+              </div>
               <button
                 onClick={() =>
                   modalImage.groupId


### PR DESCRIPTION
## Summary
- show Add Photo button in thumbnail strip only when group has multiple images
- move Add Photo button next to Download button when viewing a single image

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6877b008a36c8333b457adffbb7b7cef