### PR TITLE
Show Add Photo button only for single-image groups

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1084,17 +1084,19 @@ export default function GalleryPage() {
               <FaTrashAlt />
             </span>
             <div className="modal-action-row">
-              <div
-                className="modal-add-btn"
-                title="Add Photo"
-                onClick={openAddPhotoDialog}
-                style={{
-                  opacity: addingPhotos ? 0.6 : 1,
-                  pointerEvents: addingPhotos ? "none" : "auto",
-                }}
-              >
-                +
-              </div>
+              {modalImage.groupImages?.length === 1 && (
+                <div
+                  className="modal-add-btn"
+                  title="Add Photo"
+                  onClick={openAddPhotoDialog}
+                  style={{
+                    opacity: addingPhotos ? 0.6 : 1,
+                    pointerEvents: addingPhotos ? "none" : "auto",
+                  }}
+                >
+                  +
+                </div>
+              )}
               <button
                 onClick={() =>
                   modalImage.groupId


### PR DESCRIPTION
## Summary
- adjust modal action row so the `+` button is only shown when a group has a single image

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6877b6661e5883338baac97d237bf61d