### PR TITLE
Fix Add Photo S3 upload

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -261,11 +261,15 @@ export default function GalleryPage() {
         });
         const { uploadURL, key } = await res.json();
 
-        await fetch(uploadURL, {
+        const uploadRes = await fetch(uploadURL, {
           method: "PUT",
-          headers: { "Content-Type": file.type },
           body: file,
+          headers: { "Content-Type": file.type },
         });
+
+        if (!uploadRes.ok) {
+          throw new Error(`Upload failed: ${uploadRes.status}`);
+        }
 
         await addDoc(collection(db, "images"), {
           groupId,


### PR DESCRIPTION
## Summary
- ensure Content-Type header when uploading additional images in GalleryPage
- surface failed uploads instead of saving broken Firestore records

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6877bb42bb0883339deb7cac3f69fd5e