### PR TITLE
Add upload response logging

### DIFF
--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -164,11 +164,16 @@ export default function UploadPage() {
         });
         const { uploadURL, key } = await res.json();
 
-        await fetch(uploadURL, {
+        const uploadRes = await fetch(uploadURL, {
           method: "PUT",
           headers: { "Content-Type": file.type },
           body: file,
         });
+        console.log("Upload response status:", uploadRes.status);
+        if (!uploadRes.ok) {
+          console.log(await uploadRes.text());
+          throw new Error("Failed to upload image");
+        }
 
         // Save image record
         await addDoc(collection(db, "images"), {


### PR DESCRIPTION
## Summary
- log the HTTP status from S3 upload in UploadPage
- log the response body and throw an error on upload failure

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6877c200d2b483339721fbabfb70926e