### PR TITLE
Fix upload headers, add log

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -250,21 +250,24 @@ export default function GalleryPage() {
         const imgNum = String(lastIdx + i + 1).padStart(3, "0");
         const baseName = groupMeta.groupName || groupId;
         const generatedName = `${baseName}_${imgNum}`;
+        const fileType = file.type || "image/jpeg";
 
         const res = await fetch("http://localhost:4000/generate-upload-url", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             fileName: `${generatedName}${extension}`,
-            fileType: file.type,
+            fileType,
           }),
         });
         const { uploadURL, key } = await res.json();
 
+        console.log("Uploading:", file.name, "| type:", file.type);
+
         const uploadRes = await fetch(uploadURL, {
           method: "PUT",
           headers: {
-            "Content-Type": file.type,
+            "Content-Type": fileType,
           },
           body: file,
         });


### PR DESCRIPTION
## Summary
- log the file name and type before uploading
- fall back to `image/jpeg` when generating upload URLs
- match the upload `Content-Type` to the generated one

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_6877d6e6c23483338bc371e6067b6b3b