### PR TITLE
Add debug logging for S3 uploads

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -257,12 +257,16 @@ export default function GalleryPage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             fileName: `${generatedName}${extension}`,
-            fileType,
+            fileType: file.type || "image/jpeg",
           }),
         });
         const { uploadURL, key } = await res.json();
 
-        console.log("Uploading:", file.name, "| type:", file.type);
+        console.log("Uploading to S3 →", {
+          fileName: file.name,
+          fileType: file.type,
+          fallbackUsed: !file.type,
+        });
 
         const uploadRes = await fetch(uploadURL, {
           method: "PUT",


### PR DESCRIPTION
## Summary
- log extra details when uploading images to S3
- explicitly pass fallback file type

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6877dc859a488333a3508f5fab0a1715