### PR TITLE
Remove headers from S3 upload request

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -270,9 +270,6 @@ export default function GalleryPage() {
 
         const uploadRes = await fetch(uploadURL, {
           method: "PUT",
-          headers: {
-            "Content-Type": fileType,
-          },
           body: file,
         });
 


### PR DESCRIPTION
## Summary
- remove `Content-Type` header from S3 `fetch` call in `GalleryPage.jsx` to avoid presigned URL signature mismatch

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6877eb44bce08333bb51889a295cad5e