### PR TITLE
Show upload progress while adding photos

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -165,6 +165,7 @@ export default function GalleryPage() {
   const addInputRef = useRef(null);
   const [addingPhotos, setAddingPhotos] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [showProgress, setShowProgress] = useState(false);
 
   const pageSize = 20;
 
@@ -258,6 +259,7 @@ export default function GalleryPage() {
     }
     const groupMeta = modalImage.groupMeta || {};
     setAddingPhotos(true);
+    setShowProgress(true);
     setUploadProgress(0);
     try {
       let lastIdx = 0;
@@ -328,6 +330,7 @@ export default function GalleryPage() {
       console.error(e);
       alert("Failed to upload image(s).");
     }
+    setShowProgress(false);
     setAddingPhotos(false);
     setUploadProgress(0);
   };
@@ -610,7 +613,7 @@ export default function GalleryPage() {
         onChange={handleAddPhotoChange}
         style={{ display: "none" }}
       />
-      {addingPhotos && (
+      {showProgress && (
         <div className="upload-progress">Uploading {uploadProgress}%</div>
       )}
       {/* ====== NAV BAR ====== */}


### PR DESCRIPTION
## Summary
- add `showProgress` state in GalleryPage
- start and stop progress indicator when uploading photos
- render upload progress banner whenever `showProgress` is true

## Testing
- `npm run lint --prefix Frontend`

------
https://chatgpt.com/codex/tasks/task_b_6877f322fc5c8333a4808c38afd807aa