### PR TITLE
Update layout for single-image groups

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -404,3 +404,23 @@ button:focus-visible {
   background: #075b31;
   transform: scale(1.05);
 }
+
+.photo-modal .modal-upload-more-btn {
+  background: #09713c;
+  color: #fff;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: transform 0.15s, background-color 0.15s;
+}
+
+.photo-modal .modal-upload-more-btn:hover {
+  background: #075b31;
+  transform: scale(1.05);
+}

--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1138,8 +1138,8 @@ export default function GalleryPage() {
             </span>
             <div className="modal-action-row">
               {modalImage.groupImages?.length === 1 && (
-                <div
-                  className="modal-add-btn"
+                <button
+                  className="modal-upload-more-btn"
                   title="Add Photo"
                   onClick={openAddPhotoDialog}
                   style={{
@@ -1147,8 +1147,8 @@ export default function GalleryPage() {
                     pointerEvents: addingPhotos ? "none" : "auto",
                   }}
                 >
-                  +
-                </div>
+                  + Add More Photos
+                </button>
               )}
               <button
                 onClick={() =>


### PR DESCRIPTION
## Summary
- add CSS for new `modal-upload-more-btn`
- replace `modal-add-btn` with `modal-upload-more-btn` for single-image groups

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6878070f449883338a19be0bcfe969fd