### PR TITLE
Fix gallery modal width

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -682,6 +682,7 @@ export default function GalleryPage() {
       background: "white",
       borderRadius: "10px",
       maxWidth: "950px",
+      width: "950px",
     },
     overlay: {
       background: "rgba(0,0,0,0.5)",


### PR DESCRIPTION
## Summary
- ensure single-image modal width matches multi-image

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687a5247bbd0833399d92a4c9bb92b29