### PR TITLE
Fix layout for single-image modal

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -327,6 +327,11 @@ button:focus-visible {
   background: #fff;
 }
 
+.thumbnail-row.placeholder {
+  min-height: 88px;
+  visibility: hidden;
+}
+
 /* Modal action buttons */
 .photo-modal .modal-action-row {
   display: flex;

--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1303,6 +1303,8 @@ export default function GalleryPage() {
                 <FaTrashAlt />
               </span>
 
+              <div className="thumbnail-row placeholder" />
+
               {/* Consolidated action row */}
               <div className="modal-action-row">
                 <button


### PR DESCRIPTION
## Summary
- prevent action buttons from shifting in single-image view by adding a placeholder row
- style placeholder row to reserve thumbnail space

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e59166e288333b3b19cba5f23dcc4