### PR TITLE
Improve single-image modal layout

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -429,3 +429,33 @@ button:focus-visible {
   background: #075b31;
   transform: scale(1.05);
 }
+
+/* Centered layout for single-image folders */
+.photo-modal .single-image-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.photo-modal .single-image-container {
+  width: 100%;
+  height: 380px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+}
+
+.photo-modal .single-image-actions {
+  margin-top: 0;
+  max-width: 520px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1249,64 +1249,39 @@ export default function GalleryPage() {
             </div>
           </div>
         ) : modalImage ? (
-          <div
-            style={{
-              textAlign: "center",
-              padding: "2rem 2rem 0 2rem",
-              maxWidth: 780,
-              }}
-            >
-              <div>
-                <div style={{ fontWeight: 700, fontSize: "1.2rem" }}>
-                  {formatImageName(
-                    modalImage?.groupMeta?.groupName || modalImage?.groupId || "",
-                    0,
-                  )}
-                </div>
-              </div>
-              <div
-                style={{
-                  width: "100%",
-                  height: "380px",
-                  position: "relative",
-                  marginBottom: 16,
-                }}
-              >
-                <img
-                  src={modalImage.url}
-                  alt=""
-                  className="modal-main-image"
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    height: "100%",
-                    objectFit: "contain",
-                    display: "block",
-                  }}
-                  onDoubleClick={handleImageDoubleClick}
-                />
-              </div>
+          <div className="single-image-wrapper">
+            <div style={{ fontWeight: 700, fontSize: "1.2rem", marginBottom: "0.5rem" }}>
+              {formatImageName(
+                modalImage?.groupMeta?.groupName || modalImage?.groupId || "",
+                0,
+              )}
+            </div>
+            <div className="single-image-container">
+              <img
+                src={modalImage.url}
+                alt=""
+                className="modal-main-image"
+                style={{ maxWidth: "100%", maxHeight: "70vh", objectFit: "contain" }}
+                onDoubleClick={handleImageDoubleClick}
+              />
               <span
                 className="delete-icon"
                 title="Delete photo"
                 style={{ right: 28, bottom: 20, zIndex: 100 }}
                 onClick={() =>
                   handleDeletePhoto(
-                    modalImage.groupImages
-                      ? modalImage.groupImages[modalIndex]
-                      : modalImage,
+                    modalImage.groupImages ? modalImage.groupImages[modalIndex] : modalImage,
                   )
                 }
               >
                 <FaTrashAlt />
               </span>
+            </div>
 
-              <div className="thumbnail-row placeholder" />
+            <div className="thumbnail-row placeholder" />
 
-              {/* Consolidated action row */}
-              <div className="modal-action-row">
+            {/* Consolidated action row */}
+            <div className="modal-action-row single-image-actions">
                 <button
                   onClick={openAddPhotoDialog}
                   className="modal-upload-more-btn"
@@ -1360,8 +1335,8 @@ export default function GalleryPage() {
                   <StickyNote size={21} />
                   <span>Notes</span>
                 </button>
-              </div>
             </div>
+          </div>
         ) : null}
 
         </Modal>


### PR DESCRIPTION
## Summary
- center single-image modal contents using new flexbox wrapper
- keep buttons in a single centered row and prevent early wrapping

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687e5b9b900083338af50258421f32ef