### PR TITLE
Improve single-image modal layout

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -430,6 +430,13 @@ button:focus-visible {
   transform: scale(1.05);
 }
 
+/* Title styling for single-image folders */
+.photo-modal .modal-title {
+  text-align: center;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
 /* Centered layout for single-image folders */
 .photo-modal .single-image-wrapper {
   display: flex;
@@ -449,7 +456,7 @@ button:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
 }
 
 .photo-modal .single-image-actions {
@@ -458,4 +465,5 @@ button:focus-visible {
   width: 100%;
   margin-left: auto;
   margin-right: auto;
+  flex-wrap: nowrap;
 }

--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1250,11 +1250,8 @@ export default function GalleryPage() {
           </div>
         ) : modalImage ? (
           <div className="single-image-wrapper">
-            <div style={{ fontWeight: 700, fontSize: "1.2rem", marginBottom: "0.5rem" }}>
-              {formatImageName(
-                modalImage?.groupMeta?.groupName || modalImage?.groupId || "",
-                0,
-              )}
+            <div className="modal-title">
+              {modalImage?.groupMeta?.groupName || modalImage?.groupId || ""}
             </div>
             <div className="single-image-container">
               <img


### PR DESCRIPTION
## Summary
- show group name in modal title for single-image folders
- tweak CSS for single-image modal layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e61f20c848333a35d0f3d1ddc8514