### PR TITLE
Add group title in single-image modal

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -518,7 +518,9 @@ export default function GalleryPage() {
     const activeImg = groupImages[index] || {};
     const url =
       activeImg.s3Key ? `${BUCKET_URL}/${activeImg.s3Key}` : activeImg.url;
-    setModalImage({ url, groupId, groupImages, groupMeta });
+    const modalData = { url, groupId, groupImages, groupMeta };
+    console.log("modalImage", modalData);
+    setModalImage(modalData);
     setModalIndex(index);
     setModalOpen(true);
   };
@@ -1251,7 +1253,9 @@ export default function GalleryPage() {
         ) : modalImage ? (
           <div className="single-image-wrapper">
             <div className="modal-title">
-              {modalImage?.groupMeta?.groupName || modalImage?.groupId || ""}
+              {modalImage?.groupMeta?.groupName ||
+                modalImage?.groupId ||
+                "Untitled Group"}
             </div>
             <div className="single-image-container">
               <img


### PR DESCRIPTION
## Summary
- show single-image modal title for folder/group
- log modalImage data when opening the modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e68104eec833391bdeb22783cdaad