### PR TITLE
Add modal title debug for single-image view

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1252,6 +1252,7 @@ export default function GalleryPage() {
           </div>
         ) : modalImage ? (
           <div className="single-image-wrapper">
+            {console.log("🟡 modalImage debug", modalImage)}
             <div className="modal-title">
               {modalImage?.groupMeta?.groupName ||
                 modalImage?.groupId ||


### PR DESCRIPTION
## Summary
- log modal image details during single-image view
- show group title when viewing a single image in a group

## Testing
- `npm run lint` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e6a2d9e5083338067aeee4bc4dd8a