### PR TITLE
Fix title visibility in single image modal

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1263,10 +1263,21 @@ export default function GalleryPage() {
         ) : modalImage ? (
           <div className="single-image-wrapper">
             {console.log("🟡 modalImage debug", modalImage)}
-            <div className="modal-title">
-              {modalImage?.groupMeta?.groupName ||
-                modalImage?.groupId ||
-                "Untitled Group"}
+            <div style={{ background: "#fff", paddingTop: "1rem" }}>
+              <div
+                className="modal-title"
+                style={{
+                  textAlign: "center",
+                  fontWeight: 700,
+                  fontSize: "1.2rem",
+                  color: "#000",
+                  marginBottom: "1rem",
+                }}
+              >
+                {modalImage?.groupMeta?.groupName ||
+                  modalImage?.groupId ||
+                  "Untitled Group"}
+              </div>
             </div>
             <div className="single-image-container">
               <img


### PR DESCRIPTION
## Summary
- show single-image folder title using inline styles for better visibility

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e72275f6c83339933c72f2d6577f7