### PR TITLE
Fix single-image modal title metadata

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -530,7 +530,11 @@ export default function GalleryPage() {
       activeImg.s3Key ? `${BUCKET_URL}/${activeImg.s3Key}` : activeImg.url;
     const modalData = { url, groupId: activeGroupId, groupImages, groupMeta };
     console.log("modalImage", modalData);
-    setModalImage(modalData);
+    setModalImage({
+      ...modalData,
+      groupId: activeImg.groupId,
+      groupMeta: { ...groupMeta, groupName: activeImg.groupName || "" },
+    });
     setModalIndex(index);
     setModalOpen(true);
   };


### PR DESCRIPTION
## Summary
- ensure image groupId and groupName are included when opening the modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e74c7e86c8333a1b3de805e61a14d