### PR TITLE
Fix modal title metadata for single-image folders

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -533,7 +533,7 @@ export default function GalleryPage() {
     setModalImage({
       ...modalData,
       groupId: activeImg.groupId,
-      groupMeta: { ...groupMeta, groupName: activeImg.groupName || "" },
+      groupMeta: { groupName: activeImg.groupName || "" },
     });
     setModalIndex(index);
     setModalOpen(true);


### PR DESCRIPTION
## Summary
- ensure single-image groups populate `groupMeta.groupName` on modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687e766c2e18833391628515bd994123