### PR TITLE
Sync single-image modal layout with multi-image view

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1131,7 +1131,7 @@ export default function GalleryPage() {
           ? renderFullscreen()
           : modalImage &&
             modalImage.groupImages &&
-            modalImage.groupImages.length > 1 ? (
+            modalImage.groupImages.length ? (
           <div
             style={{
               textAlign: "center",
@@ -1159,7 +1159,7 @@ export default function GalleryPage() {
             </div>
             <Swiper
               modules={[Navigation]}
-              navigation
+              navigation={modalImage.groupImages.length > 1}
               onSwiper={setMainSwiper}
               initialSlide={modalIndex}
               onSlideChange={(swiper) => setModalIndex(swiper.activeIndex)}
@@ -1214,21 +1214,38 @@ export default function GalleryPage() {
                   }}
                 />
               ))}
-              {modalImage.groupImages.length > 1 && (
-                <div
-                  className="thumbnail add-thumb"
-                  title="Add Photo"
-                  onClick={openAddPhotoDialog}
-                  style={{
-                    opacity: addingPhotos ? 0.6 : 1,
-                    pointerEvents: addingPhotos ? "none" : "auto",
-                  }}
-                >
-                  +
-                </div>
+              {modalImage.groupImages.length === 1 && (
+                <img
+                  src="/enviroshake-logo.png"
+                  alt="Enviroshake Logo"
+                  className="thumbnail"
+                  style={{ cursor: "default" }}
+                />
               )}
+              <div
+                className="thumbnail add-thumb"
+                title="Add Photo"
+                onClick={openAddPhotoDialog}
+                style={{
+                  opacity: addingPhotos ? 0.6 : 1,
+                  pointerEvents: addingPhotos ? "none" : "auto",
+                }}
+              >
+                +
+              </div>
             </div>
             <div className="modal-action-row">
+              <button
+                onClick={openAddPhotoDialog}
+                className="modal-upload-more-btn"
+                title="Add Photo"
+                style={{
+                  opacity: addingPhotos ? 0.6 : 1,
+                  pointerEvents: addingPhotos ? "none" : "auto",
+                }}
+              >
+                <span style={{ fontSize: "1.2rem" }}>+</span> Add More Photos
+              </button>
               <button
                 onClick={() =>
                   modalImage.groupId


### PR DESCRIPTION
## Summary
- update Gallery modal to use the same markup for single-photo groups
- show Enviroshake logo thumbnail when only one photo is present
- always include Add Photo tile and Add More Photos button
- hide Swiper navigation arrows if only one slide

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6880e9acce40833392dbc65a8f6f037e