### PR TITLE
Show Enviroshake logo placeholder for single image folders

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -1216,7 +1216,7 @@ export default function GalleryPage() {
               ))}
               {modalImage.groupImages.length === 1 && (
                 <img
-                  src="/enviroshake-logo.png"
+                  src="/Enviroshake_logo/logo-enviroshake-square.jpg"
                   alt="Enviroshake Logo"
                   className="thumbnail"
                   style={{ cursor: "default" }}


### PR DESCRIPTION
## Summary
- display Enviroshake logo placeholder in thumbnail row when a folder has only one image

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6880eeff5b008333924009068ebb7b93