### PR TITLE
Fix Enviroshake logo base path

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -802,7 +802,7 @@ export default function GalleryPage() {
             style={{ display: "flex", alignItems: "center", height: "100%" }}
           >
             <img
-              src="/enviroshake-gallery/Enviroshake_logo/Enviroshake_white_logo.png"
+              src={`${import.meta.env.BASE_URL}Enviroshake_logo/Enviroshake_white_logo.png`}
               alt="Enviroshake Logo"
               style={{
                 maxHeight: "100%",
@@ -1216,7 +1216,7 @@ export default function GalleryPage() {
               ))}
               {modalImage.groupImages.length === 1 && (
                 <img
-                  src="/Enviroshake_logo/logo-enviroshake-square.jpg"
+                  src={`${import.meta.env.BASE_URL}Enviroshake_logo/logo-enviroshake-square.jpg`}
                   alt="Enviroshake Logo"
                   className="thumbnail"
                   style={{ cursor: "default" }}

--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -225,7 +225,7 @@ export default function UploadPage() {
             style={{ display: "flex", alignItems: "center", height: "100%" }}
           >
             <img
-              src="/enviroshake-gallery/Enviroshake_logo/Enviroshake_white_logo.png"
+              src={`${import.meta.env.BASE_URL}Enviroshake_logo/Enviroshake_white_logo.png`}
               alt="Enviroshake Logo"
               style={{
                 maxHeight: "100%",


### PR DESCRIPTION
## Summary
- use `import.meta.env.BASE_URL` for Enviroshake logo in header of GalleryPage and UploadPage
- update logo path for single-image thumbnail strip

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6880fdf65cfc83339007691a485c6809