### PR TITLE
Fix group download link insertion

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -435,7 +435,9 @@ export default function GalleryPage() {
       const link = document.createElement("a");
       link.href = url;
       link.download = `${groupId}.zip`;
+      document.body.appendChild(link);
       link.click();
+      link.remove();
       window.URL.revokeObjectURL(url);
     } catch {
       alert("Failed to download ZIP");


### PR DESCRIPTION
## Summary
- ensure the temporary download link for a group zip is added to the DOM
- remove the link element after triggering download

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68810bbf489c8333a4a947d2174ef313