### PR TITLE
Connect Firebase using local service account

### DIFF
--- a/Backend/firebaseAdmin.js
+++ b/Backend/firebaseAdmin.js
@@ -1,8 +1,8 @@
 const admin = require("firebase-admin");
 const path = require("path");
 
-// Adjust the path below ONLY if the JSON is in /secrets/. Otherwise use direct filename.
-const serviceAccount = require(path.resolve(__dirname, "enviroshake-service-account.json"));
+const serviceAccountPath = path.resolve(__dirname, "secrets", "firebase-service-account.json");
+const serviceAccount = require(serviceAccountPath);
 
 if (!admin.apps.length) {
   admin.initializeApp({


### PR DESCRIPTION
## Summary
- load `firebase-service-account.json` from the `secrets/` folder
- init Firebase Admin SDK only when needed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68878e879e6c833391eb011b64300ea9