### PR TITLE
Add API service helpers

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,0 +1,34 @@
+const API_BASE = "http://localhost:4000";
+
+export async function fetchImageGroups() {
+  try {
+    const res = await fetch(`${API_BASE}/image-groups`);
+    if (!res.ok) throw new Error("Failed to fetch image groups");
+    return await res.json();
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+}
+
+export async function fetchImagesByGroup(groupId) {
+  try {
+    const res = await fetch(`${API_BASE}/images/${groupId}`);
+    if (!res.ok) throw new Error("Failed to fetch images");
+    return await res.json();
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+}
+
+export async function downloadGroup(groupId) {
+  try {
+    const res = await fetch(`${API_BASE}/download-group/${groupId}`);
+    if (!res.ok) throw new Error("Failed to download group");
+    return await res.blob();
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add an API wrapper providing `fetchImageGroups`, `fetchImagesByGroup`, and `downloadGroup`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6888d21dbf4c83339dcb5443944adeed