### PR TITLE
Refactor Gallery API calls

### DIFF
--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -6,8 +6,7 @@ import { COLOR_OPTIONS } from "../Constants/colorOptions";
 import { db, auth } from "../services/firebase";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
-
-const API_BASE = "http://localhost:4000";
+import { generateUploadUrl } from "../services/api";
 
 const OPTIONS = {
   productLines: ["Enviroshake", "Enviroshingle", "EnviroSlate"],
@@ -135,15 +134,10 @@ export default function UploadPage() {
         // 👇 Debug: Check file type
         console.log("Uploading:", file.name, "| type:", file.type);
 
-        const res = await fetch(`${API_BASE}/generate-upload-url`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            fileName: `${generatedName}${extension}`,
-            fileType: file.type,
-          }),
-        });
-        const { uploadURL, key } = await res.json();
+        const { uploadURL, key } = await generateUploadUrl(
+          `${generatedName}${extension}`,
+          file.type,
+        );
 
         const uploadRes = await fetch(uploadURL, {
           method: "PUT",

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,0 +1,33 @@
+const API_BASE = "http://localhost:4000";
+
+export async function generateUploadUrl(fileName, fileType) {
+  const res = await fetch(`${API_BASE}/generate-upload-url`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ fileName, fileType }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to generate upload URL');
+  }
+  return res.json();
+}
+
+export async function downloadGroup(groupId) {
+  const res = await fetch(`${API_BASE}/download-group/${encodeURIComponent(groupId)}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch ZIP');
+  }
+  return res.blob();
+}
+
+export async function downloadMultipleGroups(groupIds) {
+  const res = await fetch(`${API_BASE}/download-multiple-groups`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupIds }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to generate ZIP');
+  }
+  return res.blob();
+}


### PR DESCRIPTION
## Summary
- add a dedicated API service module
- use API helpers in GalleryPage
- use API helpers in UploadPage
- remove direct API_BASE usage outside the service

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6888d220068883339e6b5e13fed4e4ac