### PR TITLE
chore: remove unused imports and helpers

### DIFF
--- a/Backend/server.js
+++ b/Backend/server.js
@@ -5,7 +5,7 @@ const express = require("express");
 const { S3Client, PutObjectCommand, DeleteObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const cors = require("cors");
-const { admin, db } = require("./firebaseAdmin");
+const { db } = require("./firebaseAdmin");
 const downloadGroupRoute = require("./routesDownloadGroup");
 const downloadMultipleGroupsRoute = require("./downloadMultipleGroups");
 

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -22,8 +22,7 @@
     "react-responsive-modal": "^6.4.2",
     "react-router-dom": "^7.6.2",
     "react-select": "^5.10.1",
-    "swiper": "^11.2.10",
-    "uuid": "^11.1.0"
+    "swiper": "^11.2.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -30,6 +30,7 @@ import {
   downloadGroup,
   downloadMultipleGroups,
 } from "../services/api";
+import { getFileExt } from "../utils/fileHelpers";
 
 const BUCKET_URL = "https://enviroshake-gallery-images.s3.amazonaws.com";
 
@@ -78,11 +79,6 @@ const makeOptions = (arr) => arr.map((item) => ({ label: item, value: item }));
 const formatImageName = (groupName, index) =>
   `${groupName}_${String(index + 1).padStart(3, "0")}`;
 
-const getFileExt = (fileName) => {
-  if (!fileName) return "";
-  const idx = fileName.lastIndexOf(".");
-  return idx !== -1 ? fileName.substring(idx) : "";
-};
 
 // Triggers a browser download using a temporary anchor element
 const downloadImage = (url, filename) => {

--- a/Frontend/src/pages/ProductDetail.jsx
+++ b/Frontend/src/pages/ProductDetail.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 
 const products = [

--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -7,6 +7,7 @@ import { db, auth } from "../services/firebase";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
 import { generateUploadUrl } from "../services/api";
+import { getFileExt } from "../utils/fileHelpers";
 
 const OPTIONS = {
   productLines: ["Enviroshake", "Enviroshingle", "EnviroSlate"],
@@ -81,11 +82,6 @@ export default function UploadPage() {
 
   const namePreview = `${groupId}_001`;
 
-  const getFileExt = (fileName) => {
-    if (!fileName) return "";
-    const idx = fileName.lastIndexOf(".");
-    return idx !== -1 ? fileName.substring(idx) : "";
-  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -34,14 +34,3 @@ export async function downloadMultipleGroups(groupIds) {
   return res.blob();
 }
 
-export async function fetchImageGroups() {
-  const res = await fetch(`${API_BASE}/image-groups`);
-  if (!res.ok) throw new Error("Failed to fetch image groups");
-  return await res.json();
-}
-
-export async function fetchImagesByGroup(groupId) {
-  const res = await fetch(`${API_BASE}/images/${groupId}`);
-  if (!res.ok) throw new Error("Failed to fetch images");
-  return await res.json();
-}

--- a/Frontend/src/services/firebase.js
+++ b/Frontend/src/services/firebase.js
@@ -18,4 +18,3 @@ const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);
-export const storage = getStorage(app);

--- a/Frontend/src/utils/fileHelpers.js
+++ b/Frontend/src/utils/fileHelpers.js
@@ -1,0 +1,5 @@
+export const getFileExt = (fileName) => {
+  if (!fileName) return "";
+  const idx = fileName.lastIndexOf(".");
+  return idx !== -1 ? fileName.substring(idx) : "";
+};


### PR DESCRIPTION
## Summary
- remove leftover React import and Firebase admin usage
- drop unused storage export and API helper endpoints
- centralize file extension helper and prune uuid dependency

## Testing
- `npm test` *(frontend: Missing script "test")*
- `npm test` *(backend: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6892289ad7688333a58d61b17d6f82c5