### PR TITLE
Use fileName when generating upload URLs

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -291,9 +291,10 @@ export default function GalleryPage() {
         const imgNum = String(lastIdx + i + 1).padStart(3, "0");
         const baseName = groupMeta.groupName || groupId;
         const generatedName = `${baseName}_${imgNum}`;
+        const fileName = `${generatedName}${extension}`;
 
         const { uploadURL, key } = await generateUploadUrl(
-          `${generatedName}${extension}`,
+          fileName,
           file.type || "image/jpeg",
         );
 

--- a/Frontend/src/pages/UploadPage.jsx
+++ b/Frontend/src/pages/UploadPage.jsx
@@ -126,12 +126,13 @@ export default function UploadPage() {
         const extension = getFileExt(file.name);
         const imgNum = (i + 1).toString().padStart(3, "0");
         const generatedName = `${groupId}_${imgNum}`;
+        const fileName = `${generatedName}${extension}`;
 
         // 👇 Debug: Check file type
         console.log("Uploading:", file.name, "| type:", file.type);
 
         const { uploadURL, key } = await generateUploadUrl(
-          `${generatedName}${extension}`,
+          fileName,
           file.type,
         );
 

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -2,11 +2,11 @@
 
 const API_BASE = "http://localhost:4000";
 
-export async function generateUploadUrl(filename, fileType) {
+export async function generateUploadUrl(fileName, fileType) {
   const res = await fetch(`${API_BASE}/generate-upload-url`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ filename, fileType }),
+    body: JSON.stringify({ fileName, fileType }),
   });
   if (!res.ok) {
     throw new Error("Failed to generate upload URL");

--- a/Frontend/src/services/firebase.js
+++ b/Frontend/src/services/firebase.js
@@ -18,3 +18,4 @@ const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+export const storage = getStorage(app);


### PR DESCRIPTION
## Summary
- Rename generateUploadUrl parameter to fileName and send {fileName, fileType}
- Adjust upload pages to build fileName and pass it to generateUploadUrl
- Export Firebase storage instance to avoid unused import warning

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68925d2708288333b502387585287652