### PR TITLE
Ensure downloadGroup uses Firestore key directly

### DIFF
--- a/Backend/server.js
+++ b/Backend/server.js
@@ -6,7 +6,7 @@ const { S3Client, PutObjectCommand, DeleteObjectCommand } = require("@aws-sdk/cl
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const cors = require("cors");
 const { db } = require("./firebaseAdmin");
-const downloadGroupRoute = require("./routesDownloadGroup");
+const downloadGroupRoute = require("./routes/downloadGroup");
 const downloadMultipleGroupsRoute = require("./downloadMultipleGroups");
 
 const app = express();


### PR DESCRIPTION
## Summary
- move `downloadGroup` route into `Backend/routes`
- use Firestore `s3Key` as-is in `GetObjectCommand`
- update server to load new route path

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_b_68934c4ab2748333a22bb9923db144fa