### PR TITLE
Add debug logs for thumbnail loading

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -408,10 +408,13 @@ export default function GalleryPage() {
               limit(1),
             );
             const snap = await getDocs(q);
+            console.log("Loading thumbnail for groupId:", groupId);
+            console.log("Firestore snapshot size:", snap.size);
             if (!snap.empty) {
               const { s3Key } = snap.docs[0].data();
               if (s3Key) {
                 const url = `${BUCKET_URL}/${s3Key}`;
+                console.log("Generated thumbnail URL:", url);
                 setThumbnailUrls((prev) => ({ ...prev, [groupId]: url }));
               }
             }


### PR DESCRIPTION
## Summary
- log group ID, Firestore snapshot size, and generated URL when loading thumbnails for gallery

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_689364b84ecc833398ccd066c26a103a