### PR TITLE
Log group IDs when loading thumbnails

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -398,6 +398,7 @@ export default function GalleryPage() {
 
   useEffect(() => {
     const loadThumbnails = async (groupIds) => {
+      console.log("👀 loadThumbnails triggered with:", groupIds);
       await Promise.all(
         groupIds.map(async (groupId) => {
           try {


### PR DESCRIPTION
## Summary
- log group IDs passed to `loadThumbnails`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68936c0cf23c8333b9a0d2eba6531f84