### PR TITLE
fix: align MIME type fallback to avoid S3 signature mismatch

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -271,9 +271,10 @@ export default function GalleryPage() {
         const generatedName = `${baseName}_${imgNum}`;
         const fileName = `${generatedName}${extension}`;
 
+        const fallbackType = file.type || "image/jpeg";
         const { uploadURL, key } = await generateUploadUrl(
           fileName,
-          file.type || "image/jpeg",
+          fallbackType,
         );
 
         console.log("Uploading to S3 →", {
@@ -284,7 +285,7 @@ export default function GalleryPage() {
 
         const uploadRes = await fetch(uploadURL, {
           method: "PUT",
-          headers: { "Content-Type": file.type || "application/octet-stream" },
+          headers: { "Content-Type": fallbackType },
           body: file,
         });
         if (!uploadRes.ok) {


### PR DESCRIPTION
## Summary
- ensure S3 uploads and signed URLs share the same fallback MIME type

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6894b2d5208483338ba46bd2cd31aaf6