### PR TITLE
Refactor image download URL generation

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -31,7 +31,7 @@ import {
   generateUploadUrl,
   downloadMultipleGroups,
 } from "../services/api";
-import { getFileExt } from "../utils/fileHelpers";
+import { getFileExt, srcFromImage } from "../utils/fileHelpers";
 
 const BUCKET_URL = "https://enviroshake-gallery-images.s3.amazonaws.com";
 
@@ -95,9 +95,7 @@ const downloadImage = (url, filename) => {
 // Determines the download URL from image data and triggers the download
 const handleDownload = (activeImg) => {
   if (!activeImg) return;
-  const url =
-    activeImg.s3Url ||
-    (activeImg.s3Key ? `${BUCKET_URL}/${activeImg.s3Key}` : activeImg.url);
+  const url = srcFromImage(activeImg);
   if (!url) return;
   downloadImage(url, activeImg.imageName || "image.jpg");
 };

--- a/Frontend/src/utils/fileHelpers.js
+++ b/Frontend/src/utils/fileHelpers.js
@@ -3,3 +3,12 @@ export const getFileExt = (fileName) => {
   const idx = fileName.lastIndexOf(".");
   return idx !== -1 ? fileName.substring(idx) : "";
 };
+
+const BUCKET_URL = "https://enviroshake-gallery-images.s3.amazonaws.com";
+
+export const srcFromImage = (img) => {
+  if (!img) return "";
+  if (img.s3Url) return img.s3Url;
+  if (img.s3Key) return `${BUCKET_URL}/${img.s3Key}`;
+  return img.url || "";
+};


### PR DESCRIPTION
## Summary
- Use `srcFromImage` helper when downloading images
- Add `srcFromImage` utility to centralize image URL resolution

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689cdb64227c8333ab4fe02482852655