### PR TITLE
Use imgSrc for gallery thumbnails

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -102,6 +102,11 @@ const handleDownload = (activeImg) => {
   downloadImage(url, activeImg.imageName || "image.jpg");
 };
 
+// Resolves an image object's display source
+const imgSrc = (img) =>
+  img?.s3Url ||
+  (img?.s3Key ? `${BUCKET_URL}/${img.s3Key}` : img?.url || "/fallback-thumbnail.png");
+
 
 export default function GalleryPage() {
   const [images, setImages] = useState([]);
@@ -965,6 +970,7 @@ export default function GalleryPage() {
               groupMeta?.groupName ||
               (isGroup ? groupId : groupId.replace("ungrouped-", ""));
             const displayName = formatImageName(groupName, 0);
+            const thumbSrc = imgSrc(firstImage);
             return (
               <div
                 key={groupId}
@@ -1051,18 +1057,11 @@ export default function GalleryPage() {
                 {/* Main image */}
                 <div className="image-wrapper">
                   <img
-                    src={
-                      groupMeta.thumbnailS3Key
-                        ? `https://enviroshake-gallery.s3.amazonaws.com/${groupMeta.thumbnailS3Key}`
-                        : '/fallback-thumbnail.png'
-                    }
+                    src={thumbSrc}
                     alt="Group Thumbnail"
                     className="gallery-thumbnail"
                     style={{ cursor: "pointer" }}
                     onClick={() => handleImageClick(groupId, 0)}
-                    onError={(e) => {
-                      e.currentTarget.src = '/fallback-thumbnail.png';
-                    }}
                   />
                   {isGroup && groupImages.length > 1 && (
                     <span


### PR DESCRIPTION
## Summary
- use imgSrc helper to resolve thumbnail source
- render gallery thumbnails with computed thumbSrc and remove groupMeta.thumbnailS3Key fallback logic

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689cdb6200b48333996f1c35058e5874