### PR TITLE
Refactor gallery image sourcing

### DIFF
--- a/Frontend/src/utils/imageUrl.js
+++ b/Frontend/src/utils/imageUrl.js
@@ -1,0 +1,8 @@
+const BUCKET_URL = "https://enviroshake-gallery-images.s3.amazonaws.com";
+
+export const srcFromImage = (img) => {
+  if (!img) return "";
+  if (img.s3Url) return img.s3Url;
+  if (img.s3Key) return `${BUCKET_URL}/${img.s3Key}`;
+  return img.url || "";
+};


### PR DESCRIPTION
## Summary
- centralize image URL resolution with new `srcFromImage` helper
- render gallery and modal images using `srcFromImage` with logo fallbacks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689ce266de3c8333815cf7600bcc0d2f