### PR TITLE
feat: integrate upload helpers with new backend

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,17 +1,45 @@
 // src/services/api.js
 
-const API_BASE = "http://localhost:4000";
+const API_BASE = import.meta.env.VITE_BACKEND_ORIGIN;
 
-export async function generateUploadUrl(fileName, fileType) {
+export async function generateUploadUrl({
+  groupId,
+  imageId,
+  fileType,
+  fileName,
+  isThumbnail,
+}) {
   const res = await fetch(`${API_BASE}/generate-upload-url`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ fileName, fileType }),
+    body: JSON.stringify({
+      groupId,
+      imageId,
+      fileType,
+      fileName,
+      isThumbnail,
+    }),
   });
   if (!res.ok) {
     throw new Error("Failed to generate upload URL");
   }
   return res.json();
+}
+
+export async function uploadToSignedUrl(uploadURL, fileOrBlob, contentType) {
+  const res = await fetch(uploadURL, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body: fileOrBlob,
+  });
+  if (!res.ok) {
+    throw new Error("Failed to upload to signed URL");
+  }
+  return res;
+}
+
+export function imageUrlFromKey(s3Key) {
+  return `${API_BASE}/get-object/${encodeURIComponent(s3Key)}`;
 }
 
 export async function downloadGroup(groupId) {

--- a/Frontend/src/utils/fileHelpers.js
+++ b/Frontend/src/utils/fileHelpers.js
@@ -1,14 +1,14 @@
+import { imageUrlFromKey } from "../services/api";
+
 export const getFileExt = (fileName) => {
   if (!fileName) return "";
   const idx = fileName.lastIndexOf(".");
   return idx !== -1 ? fileName.substring(idx) : "";
 };
 
-const BUCKET_URL = "https://enviroshake-gallery-images.s3.amazonaws.com";
-
 export const srcFromImage = (img) => {
   if (!img) return "";
   if (img.s3Url) return img.s3Url;
-  if (img.s3Key) return `${BUCKET_URL}/${img.s3Key}`;
+  if (img.s3Key) return imageUrlFromKey(img.s3Key);
   return img.url || "";
 };

--- a/Frontend/src/utils/imageUrl.js
+++ b/Frontend/src/utils/imageUrl.js
@@ -1,8 +1,8 @@
-const BUCKET_URL = "https://enviroshake-gallery-images.s3.amazonaws.com";
+import { imageUrlFromKey } from "../services/api";
 
 export const srcFromImage = (img) => {
   if (!img) return "";
   if (img.s3Url) return img.s3Url;
-  if (img.s3Key) return `${BUCKET_URL}/${img.s3Key}`;
+  if (img.s3Key) return imageUrlFromKey(img.s3Key);
   return img.url || "";
 };


### PR DESCRIPTION
## Summary
- use `VITE_BACKEND_ORIGIN` for API base
- support richer upload metadata and signed URL uploads
- build image URLs through backend service

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689eadd6d8608333a49b35bf01f1d331