### PR TITLE
Implement upload helper with progress

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -29,8 +29,8 @@ import { v4 as uuidv4 } from "uuid";
 import {
   generateUploadUrl,
   downloadMultipleGroups,
-  uploadToSignedUrl,
   imageUrlFromKey,
+  uploadFileWithProgress,
 } from "../services/api";
 import { getFileExt } from "../utils/fileHelpers";
 


### PR DESCRIPTION
## Summary
- add uploadFileWithProgress helper to PUT files to signed URLs with progress callback
- use uploadFileWithProgress in GalleryPage for image uploads

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689f42a7ed2c83338a839c943bbf15bc