### PR TITLE
Add helper for downloading multiple groups

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,5 +1,28 @@
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
 
+export async function downloadMultipleGroups(groupIds) {
+  if (!Array.isArray(groupIds) || groupIds.length === 0) {
+    throw new Error("Missing groupIds");
+  }
+  const url = `${API_BASE}/download-multiple-groups`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ groupIds }),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`HTTP ${res.status} – ${txt || "request failed"}`);
+  }
+  const ctype = res.headers.get("content-type") || "";
+  if (!ctype.includes("application/zip")) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Expected application/zip, got ${ctype}. ${txt}`);
+  }
+  return await res.blob();
+}
+
 export async function downloadGroup(groupId) {
   if (!groupId) throw new Error("Missing groupId");
   const url = `${API_BASE}/download-group/${encodeURIComponent(groupId)}`;


### PR DESCRIPTION
## Summary
- add `downloadMultipleGroups` API helper to fetch zip of multiple groups

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68ae116906008333b77b299e281e5b53