### PR TITLE
feat: add id normalization for group lookups

### DIFF
--- a/Backend/routesDownloadGroup.js
+++ b/Backend/routesDownloadGroup.js
@@ -67,6 +67,14 @@ function s3KeyEligible(k) {
   return wasUrl ? true : ACCEPT_PREFIXES.some((p) => key.startsWith(p));
 }
 
+function normalizeId(str) {
+  return String(str || "")
+    .toLowerCase()
+    .trim()
+    .replace(/[\s_]+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
+}
+
 // Generate candidate strings for matching group ids/names robustly
 function makeCandidates(raw) {
   const base = String(raw || "").trim();
@@ -85,7 +93,15 @@ function makeCandidates(raw) {
     compact(stripTrailingCounter(s)),
   ]);
 
-  return Array.from(new Set([...seeds, ...stripped].filter(Boolean)));
+  const all = [...seeds, ...stripped].filter(Boolean);
+  const map = new Map();
+  for (const s of all) {
+    const n = normalizeId(s);
+    if (!n) continue;
+    if (!map.has(n)) map.set(n, s);
+  }
+  const out = new Set([...map.values(), ...map.keys()]);
+  return Array.from(out);
 }
 
 // fetch docs where a field == value from both top-level images and any subcollection named "images"


### PR DESCRIPTION
## Summary
- add `normalizeId` helper to standardize group identifiers
- use normalized IDs when generating candidates for group lookup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1c6098248333ad249f6bc0344dec