### PR TITLE
Fix gallery group download handler

### DIFF
--- a/Frontend/src/pages/GalleryPage.jsx
+++ b/Frontend/src/pages/GalleryPage.jsx
@@ -972,6 +972,7 @@ export default function GalleryPage() {
             const groupImages = grouped[groupId];
             const firstImage = groupImages[0];
             const groupMeta = groups[groupId];
+            const group = groupMeta || { groupId };
             const isGroup = groupImages.length > 1 || groupMeta;
             const internalOnly = isInternalOnly(groupMeta, firstImage);
             const groupName =
@@ -1019,7 +1020,7 @@ export default function GalleryPage() {
                   {/* Download Center */}
                   <div style={{ display: "flex", justifyContent: "center" }}>
                     <button
-                      onClick={() => handleDownloadGroup(groupId)}
+                      onClick={() => handleDownloadGroup(group.groupId)}
                       className={`download-btn ${
                         internalOnly ? "disabled" : ""
                       }`}


### PR DESCRIPTION
## Summary
- Use group object to reference groupId when downloading a gallery group
- Ensure group object is defined when mapping gallery groups

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b0998d6cb883339e01717a97d7c2d3