### PR TITLE
feat: add groupId decoding logs

### DIFF
--- a/Backend/routesDownloadGroup.js
+++ b/Backend/routesDownloadGroup.js
@@ -302,8 +302,11 @@ router.get("/find", async (req, res) => {
 
 // GET /download-group/:groupId
 router.get("/:groupId", async (req, res) => {
-  const raw0 = decodeURIComponent(req.params.groupId || "");
-  const raw = raw0.trim();
+  const groupIdRaw = req.params.groupId;
+  const groupId = decodeURIComponent(groupIdRaw);
+  console.log('[download-group] raw param:', groupIdRaw);
+  console.log('[download-group] decoded:', groupId);
+  const raw = groupId.trim();
   const candidates = makeCandidates(raw);
 
   try {
@@ -311,6 +314,8 @@ router.get("/:groupId", async (req, res) => {
     console.log("🔎 Candidates to check:", candidates);
 
     let imageDocs = await unionDocsForCandidates(candidates);
+    console.log('[download-group] images found:', Array.isArray(imageDocs) ? imageDocs.length : 'not-array');
+    console.log('[download-group] sample:', Array.isArray(imageDocs) ? imageDocs.slice(0, 3) : imageDocs);
     console.log("🧮 Docs found before dedupe:", imageDocs.length);
 
     imageDocs = dedupeByNormalizedKey(imageDocs);


### PR DESCRIPTION
## Summary
- add explicit logging for raw and decoded groupId in /download-group
- log image doc counts and samples after Firestore query

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_b_68b09be2f73c833388eeb48fd3953e9b