### PR TITLE
Normalize API base URL and improve API service

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,4 +1,41 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? "").replace(/\/+$/, "");
+
+async function fetchJson(url, opts) {
+  const res = await fetch(url, opts);
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`HTTP ${res.status} – ${txt || "request failed"}`);
+  }
+  const ctype = res.headers.get("content-type") || "";
+  if (!ctype.includes("application/json")) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Expected application/json, got ${ctype}. ${txt}`);
+  }
+  return res.json();
+}
+
+export async function generateUploadUrl(fileName, fileType) {
+  if (!fileName || !fileType) {
+    throw new Error("Missing fileName or fileType");
+  }
+  const body = JSON.stringify({ fileName, fileType });
+  const paths = ["/generate-upload-url", "/presign-upload", "/presign"];
+  let lastErr = null;
+  for (const p of paths) {
+    try {
+      const url = `${API_BASE}${p}`;
+      return await fetchJson(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        body,
+      });
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw lastErr || new Error("All presign paths failed");
+}
 
 export async function downloadMultipleGroups(groupIds) {
   if (!Array.isArray(groupIds) || groupIds.length === 0) {
@@ -20,26 +57,22 @@ export async function downloadMultipleGroups(groupIds) {
     const txt = await res.text().catch(() => "");
     throw new Error(`Expected application/zip, got ${ctype}. ${txt}`);
   }
-  return await res.blob();
+  return res.blob();
 }
 
 export async function downloadGroup(groupId) {
   if (!groupId) throw new Error("Missing groupId");
   const url = `${API_BASE}/download-group/${encodeURIComponent(groupId)}`;
-
   const res = await fetch(url, { method: "GET", credentials: "include" });
-
   if (!res.ok) {
     const txt = await res.text().catch(() => "");
     throw new Error(`HTTP ${res.status} – ${txt || "request failed"}`);
   }
-
   const ctype = res.headers.get("content-type") || "";
   if (!ctype.includes("application/zip")) {
     const txt = await res.text().catch(() => "");
     throw new Error(`Expected application/zip, got ${ctype}. ${txt}`);
   }
-
-  return await res.blob();
+  return res.blob();
 }
 


### PR DESCRIPTION
## Summary
- Normalize API base URL to avoid trailing slash issues
- Validate response content-types and try multiple presign paths when generating upload URLs
- Keep download helpers verifying ZIP responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68b1a32ba3b48333be33df85318fd1cd